### PR TITLE
fixed SoapFault::faultcode not being passed thru in REST response

### DIFF
--- a/src/Services/Soap.php
+++ b/src/Services/Soap.php
@@ -293,11 +293,14 @@ class Soap extends BaseRestService
             throw new NotFoundException("Function '$function' does not exist on this service.");
         }
 
-        $result = $this->client->$function($payload);
+        try {
+            $result = $this->client->$function($payload);
+            $result = static::object2Array($result);
 
-        $result = static::object2Array($result);
-
-        return $result;
+            return $result;
+        } catch (\SoapFault $e) {
+            throw new InternalServerErrorException($e->getMessage(), $e->faultcode);
+        }
     }
 
     /**


### PR DESCRIPTION
as suggested by @df-arif in https://github.com/dreamfactorysoftware/dreamfactory/issues/76

Note by @df-arif : Additional work might be required (by you guys)

However its working fine so far for me e.g. getting SOAP faultcode in REST response `{"error": { "code":`
