### PR TITLE
release: develop → master cut for Laravel 13 / PHP 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
   "prefer-stable": true,
   "require":           {
     "php": "^8.0",
-    "dreamfactory/df-core": "~1.0"
+    "dreamfactory/df-core": "~1.0",
+    "dreamfactory/df-system": "~0.5"
   },
   "autoload":          {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,17 @@
   },
   "prefer-stable": true,
   "require":           {
-    "php": "^8.0",
-    "dreamfactory/df-core": "~1.0"
+    "php": "^8.3",
+    "ext-soap": "*",
+    "laravel/helpers": "^1.8",
+    "dreamfactory/df-core": "~1.0.4"
+  },
+  "require-dev": {
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":          {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Security">
+            <directory>tests/Security</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Services/Soap.php
+++ b/src/Services/Soap.php
@@ -27,6 +27,39 @@ class Soap extends BaseRestService
 {
     use Cacheable;
 
+    /**
+     * Reject stream_context options that would disable TLS certificate
+     * verification on the WSDL fetch or SOAP request.
+     *
+     * Without this guard, an admin (or compromised admin account) could
+     * configure verify_peer=false / allow_self_signed=true and turn the
+     * outbound SOAP traffic into a MITM target.
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function assertSafeStreamContext(array $context): void
+    {
+        $ssl = $context['ssl'] ?? [];
+        if (!is_array($ssl)) {
+            return;
+        }
+        if (array_key_exists('verify_peer', $ssl) && $ssl['verify_peer'] === false) {
+            throw new \InvalidArgumentException(
+                'SOAP stream_context: ssl.verify_peer=false is not allowed.'
+            );
+        }
+        if (array_key_exists('verify_peer_name', $ssl) && $ssl['verify_peer_name'] === false) {
+            throw new \InvalidArgumentException(
+                'SOAP stream_context: ssl.verify_peer_name=false is not allowed.'
+            );
+        }
+        if (array_key_exists('allow_self_signed', $ssl) && $ssl['allow_self_signed'] === true) {
+            throw new \InvalidArgumentException(
+                'SOAP stream_context: ssl.allow_self_signed=true is not allowed.'
+            );
+        }
+    }
+
     //*************************************************************************
     //* Members
     //*************************************************************************
@@ -80,12 +113,27 @@ class Soap extends BaseRestService
                 throw new \InvalidArgumentException('SOAP Services require either a WSDL or both location and URI to be configured.');
             }
         } else {
-            if ((!str_contains($this->wsdl, '/')) && (!str_contains($this->wsdl, '\\'))) {
+            // SSRF: if the WSDL is a URL, validate scheme + host before
+            // SoapClient fetches it. SoapClient uses libxml under the hood
+            // which will follow http(s) URLs to load the WSDL document.
+            if (preg_match('#^https?://#i', $this->wsdl) === 1) {
+                \DreamFactory\Core\System\Components\SsrfValidator::validateExternalUrl($this->wsdl);
+            } elseif ((!str_contains($this->wsdl, '/')) && (!str_contains($this->wsdl, '\\'))) {
                 // no directories involved, store it where we want to store it
                 if (!empty($storage = storage_path('wsdl'))) {
                     $this->wsdl = rtrim($storage, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $this->wsdl;
                 }
             } elseif (false !== $path = realpath($this->wsdl)) {
+                // Reject symlink-traversal: the resolved path must stay
+                // inside storage_path('wsdl'). Without this, a symlink in
+                // the wsdl directory could redirect SoapClient to load a
+                // private file on disk.
+                $allowedRoot = realpath(storage_path('wsdl'));
+                if ($allowedRoot && !str_starts_with($path, $allowedRoot . DIRECTORY_SEPARATOR) && $path !== $allowedRoot) {
+                    throw new \InvalidArgumentException(
+                        'WSDL path resolves outside the allowed storage directory.'
+                    );
+                }
                 $this->wsdl = $path;
             }
         }
@@ -107,6 +155,11 @@ class Soap extends BaseRestService
                         if (!is_array($value)) {
                             throw new \InvalidArgumentException('SOAP Services stream_context must be a valid array (or JSON object) of parameters.');
                         }
+                        // Reject TLS-verification bypass options. Without
+                        // this an admin (or compromised admin account)
+                        // could disable certificate validation on WSDL
+                        // fetch and SOAP request, enabling MITM.
+                        self::assertSafeStreamContext($value);
                         $context = stream_context_create($value);
                         $options[$key] = $context;
                     }

--- a/tests/Security/SoapHardeningTest.php
+++ b/tests/Security/SoapHardeningTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace DreamFactory\Core\Soap\Tests\Security;
+
+use DreamFactory\Core\Soap\Services\Soap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security: SOAP service must
+ *   1. SSRF-validate the WSDL URL when configured as http(s)
+ *   2. Reject stream_context options that disable TLS verification
+ *   3. Reject WSDL paths whose realpath() resolves outside storage_path('wsdl')
+ *
+ * Native PHP SoapClient does not enable LIBXML_NONET / entity-loader
+ * controls on its own — and admin-configurable stream_context offered
+ * an easy MITM path via verify_peer=false. The realpath() use also let
+ * a symlink in the wsdl directory redirect SoapClient to load any file
+ * the webserver user could read.
+ */
+class SoapHardeningTest extends TestCase
+{
+    /**
+     * @dataProvider unsafeStreamContextProvider
+     */
+    public function testRejectsTlsBypassStreamContext(array $context): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Soap::assertSafeStreamContext($context);
+    }
+
+    public static function unsafeStreamContextProvider(): array
+    {
+        return [
+            'verify_peer false'        => [['ssl' => ['verify_peer' => false]]],
+            'verify_peer_name false'   => [['ssl' => ['verify_peer_name' => false]]],
+            'allow_self_signed true'   => [['ssl' => ['allow_self_signed' => true]]],
+            'multiple unsafe'          => [['ssl' => ['verify_peer' => false, 'allow_self_signed' => true]]],
+        ];
+    }
+
+    /**
+     * @dataProvider safeStreamContextProvider
+     */
+    public function testAcceptsSafeStreamContext(array $context): void
+    {
+        Soap::assertSafeStreamContext($context);
+        $this->assertTrue(true);
+    }
+
+    public static function safeStreamContextProvider(): array
+    {
+        return [
+            'empty'                    => [[]],
+            'no ssl block'             => [['http' => ['method' => 'GET']]],
+            'verify_peer true'         => [['ssl' => ['verify_peer' => true]]],
+            'cafile only'              => [['ssl' => ['cafile' => '/etc/ssl/certs/ca.pem']]],
+        ];
+    }
+
+    public function testSourceCallsSsrfValidatorOnWsdlUrl(): void
+    {
+        $sourcePath = __DIR__ . '/../../src/Services/Soap.php';
+        $this->assertFileExists($sourcePath);
+        $contents = file_get_contents($sourcePath);
+
+        $this->assertMatchesRegularExpression(
+            '/SsrfValidator::validateExternalUrl\s*\(\s*\$this->wsdl\s*\)/',
+            $contents,
+            'WSDL URL must be passed through SsrfValidator before SoapClient fetches it.'
+        );
+    }
+
+    public function testSourceEnforcesSymlinkBoundary(): void
+    {
+        $sourcePath = __DIR__ . '/../../src/Services/Soap.php';
+        $contents = file_get_contents($sourcePath);
+
+        $this->assertMatchesRegularExpression(
+            '/realpath\s*\(\s*storage_path\s*\(\s*[\'"]wsdl[\'"]\s*\)\s*\)/',
+            $contents,
+            'WSDL realpath result must be checked against the storage_path(wsdl) root.'
+        );
+        $this->assertMatchesRegularExpression(
+            '/str_starts_with\s*\(\s*\$path/',
+            $contents,
+            'Symlink boundary check must use str_starts_with on the resolved path.'
+        );
+    }
+
+    public function testSourceCallsAssertSafeStreamContext(): void
+    {
+        $sourcePath = __DIR__ . '/../../src/Services/Soap.php';
+        $contents = file_get_contents($sourcePath);
+
+        $this->assertMatchesRegularExpression(
+            '/(self|static)::assertSafeStreamContext\s*\(/',
+            $contents,
+            'Soap constructor must call assertSafeStreamContext on the parsed stream_context value.'
+        );
+    }
+}


### PR DESCRIPTION
## Release prep: cut develop into master/main

Releases this package's `develop` line for the upcoming **DreamFactory
Laravel 13 + PHP 8.5** release.

### Verification

The develop HEAD on this branch is the SHA locked into the L13/PHP 8.5
test bundle that the team has been smoking. **Full end-to-end smoke
passed 2026-05-26**: PHP 8.5.5, Laravel 13.11.2, `df:setup` seeders,
admin login → JWT, service-type registration (81 types), Postgres
schema introspection + CRUD, OpenAPI generation.

### Coordinated release PRs

This is one of ~26 coordinated `develop → master/main` PRs opened
together as the release cut. Suggested merge order:

1. **Foundation**: df-core → df-system → df-user → df-database
2. **Connectors**: df-sqldb, df-sqlsrv, df-mongodb, df-oracledb, df-snowflake, df-soap, df-salesforce, df-script
3. **Auth**: df-oauth → df-adldap, df-azure-ad, df-oidc, df-saml
4. **Services**: df-email, df-file, df-cache, df-limits, df-logger, df-scheduler
5. **AI tier**: df-ai → df-ai-chat → df-mcp-server
6. **Admin UI**: df-admin-interface
7. **Host app**: dreamfactory/dreamfactory (released last)

### Customer upgrade path

In-place on Docker / managed Linux packages; blue-green strongly
recommended on Windows + custom-PHP-extension installs. Pre-flight
checklist in the release notes.
